### PR TITLE
Correct matplotlib deprecation warning

### DIFF
--- a/python36/03_stf/GBM_returns.py
+++ b/python36/03_stf/GBM_returns.py
@@ -133,7 +133,7 @@ def return_histogram(data):
     ''' Plots a histogram of the returns. '''
     plt.figure(figsize=(9, 5))
     x = np.linspace(min(data['returns']), max(data['returns']), 100)
-    plt.hist(np.array(data['returns']), bins=50, normed=True)
+    plt.hist(np.array(data['returns']), bins=50, density=True)
     y = dN(x, np.mean(data['returns']), np.std(data['returns']))
     plt.plot(x, y, linewidth=2)
     plt.xlabel('log returns')


### PR DESCRIPTION
/home/jovyan/dawp/python36/03_stf/GBM_returns.py:136: MatplotlibDeprecationWarning: 
The 'normed' kwarg was deprecated in Matplotlib 2.1 and will be removed in 3.1. Use 'density' instead.
  plt.hist(np.array(data['returns']), bins=50, normed=True)